### PR TITLE
optimize: optimized the shdict node struct memory layout which can sa…

### DIFF
--- a/src/ngx_stream_lua_shdict.h
+++ b/src/ngx_stream_lua_shdict.h
@@ -13,12 +13,11 @@
 
 typedef struct {
     u_char                       color;
-    u_char                       dummy;
-    u_short                      key_len;
-    ngx_queue_t                  queue;
-    uint64_t                     expires;
     uint8_t                      value_type;
+    u_short                      key_len;
     uint32_t                     value_len;
+    uint64_t                     expires;
+    ngx_queue_t                  queue;
     uint32_t                     user_flags;
     u_char                       data[1];
 } ngx_stream_lua_shdict_node_t;


### PR DESCRIPTION
…ve 8 bytes for every key-value pair on 64-bit systems, for example.

sync from: https://github.com/openresty/lua-nginx-module/commit/da08f59ae5ff0f230595322b3a8ce48bd42f1b3f